### PR TITLE
Complex matrix support

### DIFF
--- a/EigenLab.h
+++ b/EigenLab.h
@@ -1,4 +1,4 @@
-// --*-  Mode: C++; c-basic-offset: 8 -*--
+// --*-  Mode: C++; c-basic-offset:8; indent-tabs-mode:t; tab-width:8 -*--
 // EigenLab
 // Version: 1.0.0
 // Author: Dr. Marcel Paz Goldschen-Ohm

--- a/EigenLab.h
+++ b/EigenLab.h
@@ -152,6 +152,7 @@ namespace EigenLab
 		};
 		enum ChunkType { VALUE = 0, VARIABLE, OPERATOR, FUNCTION };
 		typedef std::vector<Chunk> ChunkArray;
+		typedef typename Derived::Index Index;
 		bool mCacheChunkedExpressions;
 		std::map<std::string, ChunkArray> mCachedChunkedExpressions;
 		
@@ -574,7 +575,7 @@ namespace EigenLab
 						if(sfirst == slast) {
 							submatrix.local().setConstant(1, 1, sfirst);
 							submatrix.mapLocal();
-						} else if((slast - sfirst) / sstep > 0) {
+						} else if((slast - sfirst >= 0 && sstep > 0) || (slast - sfirst <= 0 && sstep < 0)) {
 							int n = floor((slast - sfirst) / sstep) + 1;
 							submatrix.local().resize(1, n);
 							for(int k = 0; k < n; ++k)
@@ -1489,7 +1490,7 @@ namespace EigenLab
 		resultValue = eval("absmax(a, 0)");
 		resultMatrix = a34.colwise().maxCoeff();
 		temp = a34.colwise().minCoeff();
-		for(Eigen::Index i = 0; i < resultMatrix.size(); ++i) {
+		for(Index i = 0; i < resultMatrix.size(); ++i) {
 			if(std::abs(resultMatrix(i)) < std::abs(temp(i)))
 				resultMatrix(i) = temp(i);
 		}
@@ -1500,7 +1501,7 @@ namespace EigenLab
 		resultValue = eval("absmax(a, 1)");
 		resultMatrix = a34.rowwise().maxCoeff();
 		temp = a34.rowwise().minCoeff();
-		for(Eigen::Index i = 0; i < resultMatrix.size(); ++i) {
+		for(Index i = 0; i < resultMatrix.size(); ++i) {
 			if(std::abs(resultMatrix(i)) < std::abs(temp(i)))
 				resultMatrix(i) = temp(i);
 		}
@@ -1701,7 +1702,7 @@ namespace EigenLab
 		std::cout << "Test matrix coefficient-wise power a .^ b: ";
 		resultValue = eval("abs(a) .^ b");
 		resultMatrix = a34;
-		for(Eigen::Index i = 0; i < a34.size(); ++i)
+		for(Index i = 0; i < a34.size(); ++i)
 			resultMatrix(i) = pow(std::abs(a34(i)), b34(i));
 		//		std::cout << std::endl;
 		//		std::cout << "a=" << std::endl << a34 << std::endl << std::endl;
@@ -1714,7 +1715,7 @@ namespace EigenLab
 		std::cout << "Test matrix/scalar coefficient-wise power a ^ s: ";
 		resultValue = eval("abs(a) ^ s");
 		resultMatrix = a34;
-		for(Eigen::Index i = 0; i < a34.size(); ++i)
+		for(Index i = 0; i < a34.size(); ++i)
 			resultMatrix(i) = pow(std::abs(a34(i)), s);
 		if(resultMatrix.isApprox(resultValue.matrix())) std::cout << "OK" << std::endl;
 		else { std::cout << "FAIL" << std::endl; ++numFails; }
@@ -1722,7 +1723,7 @@ namespace EigenLab
 		std::cout << "Test scalar/matrix coefficient-wise power s ^ b: ";
 		resultValue = eval("s ^ b");
 		resultMatrix = b34;
-		for(Eigen::Index i = 0; i < b34.size(); ++i)
+		for(Index i = 0; i < b34.size(); ++i)
 			resultMatrix(i) = pow(s, b34(i));
 		if(resultMatrix.isApprox(resultValue.matrix())) std::cout << "OK" << std::endl;
 		else { std::cout << "FAIL" << std::endl; ++numFails; }
@@ -1730,7 +1731,7 @@ namespace EigenLab
 		std::cout << "Test matrix/scalar coefficient-wise power a .^ s: ";
 		resultValue = eval("abs(a) .^ s");
 		resultMatrix = a34;
-		for(Eigen::Index i = 0; i < a34.size(); ++i)
+		for(Index i = 0; i < a34.size(); ++i)
 			resultMatrix(i) = pow(std::abs(a34(i)), s);
 		if(resultMatrix.isApprox(resultValue.matrix())) std::cout << "OK" << std::endl;
 		else { std::cout << "FAIL" << std::endl; ++numFails; }
@@ -1738,7 +1739,7 @@ namespace EigenLab
 		std::cout << "Test scalar/matrix coefficient-wise power s .^ b: ";
 		resultValue = eval("s .^ b");
 		resultMatrix = b34;
-		for(Eigen::Index i = 0; i < b34.size(); ++i)
+		for(Index i = 0; i < b34.size(); ++i)
 			resultMatrix(i) = pow(s, b34(i));
 		if(resultMatrix.isApprox(resultValue.matrix())) std::cout << "OK" << std::endl;
 		else { std::cout << "FAIL" << std::endl; ++numFails; }


### PR DESCRIPTION
This patch just removes the min/max/absmax functions in the case where the Scalar type doesn't support comparison.  Requires c++11.