### PR TITLE
add travisci testing against multiple versions of eigen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ compiler:
   - gcc
   - clang
 
-#sudo: false
-sudo: required
+sudo: false
+#sudo: required
 dist: trusty
 
 addons:
@@ -13,10 +13,13 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - cmake
-    - libeigen3-dev
     - gcc-4.9
     - g++-4.9
     - clang
+
+env:
+  - EIGEN_VERSION=3.2.10
+  - EIGEN_VERSION=3.3.3
 
 before_install:
   - ${CXX} --version;
@@ -25,7 +28,7 @@ before_install:
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   - cd tests
-  - cmake .
+  - cmake . -DEIGEN_VERSION=${EIGEN_VERSION}
   - make VERBOSE=1
 
 script: 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,11 +6,27 @@ cmake_minimum_required (VERSION 2.8)
 
 project (EigenLab CXX)
 
-find_package (PkgConfig)
-pkg_check_modules (EIGEN3 REQUIRED eigen3)
+set (EIGEN_VERSION "3.3.3" CACHE STRING "Select Eigen Version.")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+message ("Testing EigenLab against Eigen-${EIGEN_VERSION}")
+
+#
+# Eigen
+#
+include (ExternalProject)
+ExternalProject_Add (eigenX
+  PREFIX eigenX
+  URL http://bitbucket.org/eigen/eigen/get/${EIGEN_VERSION}.tar.bz2
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  LOG_DOWNLOAD ON
+  )
+ExternalProject_Get_Property (eigenX source_dir)
+set (EIGEN3_INCLUDE_DIRS "${source_dir}")
 
 include_directories ("${PROJECT_SOURCE_DIR}/..")
 include_directories ("${EIGEN3_INCLUDE_DIRS}")
@@ -18,6 +34,7 @@ include_directories ("${EIGEN3_INCLUDE_DIRS}")
 add_definitions (-DDEBUG)
 add_definitions (-D_GLIBCXX_DEBUG)
 add_executable (Test Test.cpp)
+add_dependencies (Test eigenX)
 
 enable_testing ()
 add_test (basic Test)


### PR DESCRIPTION
add 'scientific notation' fp input
fix a small bug accessing non-existant variables
change travisci tests to run against multiple versions of Eigen